### PR TITLE
Highlight refactor

### DIFF
--- a/handlers/search.go
+++ b/handlers/search.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"html/template"
 	"log"
+	"regexp"
 
 	"net/http"
 	"strings"
@@ -92,11 +93,11 @@ func (h indexHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func highlightTerm(fts []string, results []*VerseResult, isPhrase bool) {
 
-	parseResults := make(map[string]template.HTML)
+	// parseResults := make(map[string]template.HTML)
 
 	for _, v := range results {
 
-		ref := fmt.Sprintf("%s %d:%d", v.Book, v.Chapter, v.Verse)
+		// ref := fmt.Sprintf("%s %d:%d", v.Book, v.Chapter, v.Verse)
 
 		//highlight term
 		verse := v.Content.Text
@@ -104,13 +105,31 @@ func highlightTerm(fts []string, results []*VerseResult, isPhrase bool) {
 			// clean terms
 			t = strings.Trim(strings.ReplaceAll(t, "'", ""), " ")
 
-			verse = strings.Replace(verse, t, fmt.Sprintf("<i class='highlight'>%s</i>", t), -1)
-			verse = strings.Replace(verse, strings.Title(t), fmt.Sprintf("<i class='highlight'>%s</i>", strings.Title(t)), -1)
+			// convert verse string to []string and for each item do strings.contains
+			vSlice := strings.Split(verse, " ")
+
+			for i, wrd := range vSlice {
+				preSpan := "<span class='highlight'>"
+				postSpan := "</span>"
+				if strings.Contains(wrd, t) || strings.Contains(wrd, strings.Title(t)) {
+
+					// if last character is a symbol pull it out and add it after postSpan
+					lastCh := wrd[len(wrd)-1:]
+					matched, _ := regexp.MatchString(`\W`, lastCh)
+					if matched {
+						vSlice[i] = preSpan + wrd[:len(wrd)-1] + postSpan + lastCh
+					} else {
+						vSlice[i] = preSpan + wrd + postSpan
+					}
+
+				}
+			}
+			verse = strings.Join(vSlice, " ")
 
 		}
-		textParsed := template.HTML(verse)
+		// textParsed := template.HTML(verse)
 
-		parseResults[ref] = textParsed
+		// parseResults[ref] = textParsed
 
 		v.VerseHtml = template.HTML(verse)
 	}

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -97,8 +97,6 @@ func highlightTerm(fts []string, results []*VerseResult, isPhrase bool) {
 
 	for _, v := range results {
 
-		// ref := fmt.Sprintf("%s %d:%d", v.Book, v.Chapter, v.Verse)
-
 		//highlight term
 		verse := v.Content.Text
 		for _, t := range fts {
@@ -127,9 +125,6 @@ func highlightTerm(fts []string, results []*VerseResult, isPhrase bool) {
 			verse = strings.Join(vSlice, " ")
 
 		}
-		// textParsed := template.HTML(verse)
-
-		// parseResults[ref] = textParsed
 
 		v.VerseHtml = template.HTML(verse)
 	}

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -92,9 +92,6 @@ func (h indexHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func highlightTerm(fts []string, results []*VerseResult, isPhrase bool) {
-
-	// parseResults := make(map[string]template.HTML)
-
 	for _, v := range results {
 
 		//highlight term


### PR DESCRIPTION
Refactors highlight to contain full word.

Does not support phrases yet
Discovered new issue where some words do not match their tokenized version (ex: Mary and 'mari')
I do wonder if there is a way I can have Postgres do this highlighting for me.